### PR TITLE
Update CI definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: php
 php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 5.5
+    - php: 5.6
+
 install:
   - composer install
 script:


### PR DESCRIPTION
  - allow php 5.* to fail (EOL reached a looong time ago & hoping that people do not use those versions in 2019)
  - add PHP 7.2-3 to the job matrix