### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "guzzlehttp/guzzle": "~7.3"
+    "guzzlehttp/guzzle": "7.2.*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
Guzzle 7.3.0 no longer uses build_query

PHP Fatal error:  Uncaught Error: Call to undefined function GuzzleHttp\Psr7\build_query() in /var/www/php-doofinder/src/Management/PhpClient/Api/SearchEnginesApi.php:1379