### PR TITLE
FIX search url

### DIFF
--- a/src/Search/Resources/SearchResource.php
+++ b/src/Search/Resources/SearchResource.php
@@ -13,6 +13,6 @@ abstract class SearchResource extends Resource
      */
     public function getUrl()
     {
-        return $this->config->getBaseUrl() . '/6';
+        return str_replace('api', 'search', $this->config->getBaseUrl()) . '/6';
     }
 }


### PR DESCRIPTION
Search requests always result in 404 not found, because getUrl() returns the base url from the config which is "https://{search_zone}-api.doofinder.com". For search request the base url should be "https://{search_zone}-search.doofinder.com"