### PR TITLE
PHP8 Compatibility: Annotate return types for jsonSerialize() implementations

### DIFF
--- a/src/Management/Model/DataSource.php
+++ b/src/Management/Model/DataSource.php
@@ -58,7 +58,7 @@ class DataSource implements ModelInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'type' => $this->type,

--- a/src/Management/Model/DataSourceOptionBigCommerce.php
+++ b/src/Management/Model/DataSourceOptionBigCommerce.php
@@ -33,7 +33,7 @@ class DataSourceOptionBigCommerce extends DataSourceOption
     /**
      * @return string[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'url' => $this->url,

--- a/src/Management/Model/DataSourceOptionEkm.php
+++ b/src/Management/Model/DataSourceOptionEkm.php
@@ -27,7 +27,7 @@ class DataSourceOptionEkm extends DataSourceOption
     /**
      * @return string[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'url' => $this->url,

--- a/src/Management/Model/DataSourceOptionFile.php
+++ b/src/Management/Model/DataSourceOptionFile.php
@@ -27,7 +27,7 @@ class DataSourceOptionFile extends DataSourceOption
     /**
      * @return string[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'url' => $this->url,

--- a/src/Management/Model/DataSourceOptionMagento.php
+++ b/src/Management/Model/DataSourceOptionMagento.php
@@ -19,7 +19,7 @@ class DataSourceOptionMagento extends DataSourceOption
     /**
      * @return string[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'url' => $this->url

--- a/src/Management/Model/DataSourceOptionShopify.php
+++ b/src/Management/Model/DataSourceOptionShopify.php
@@ -27,7 +27,7 @@ class DataSourceOptionShopify extends DataSourceOption
     /**
      * @return string[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'url' => $this->url,

--- a/src/Management/Model/Index.php
+++ b/src/Management/Model/Index.php
@@ -64,7 +64,7 @@ class Index implements ModelInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'name' => $this->name,

--- a/src/Management/Model/Item.php
+++ b/src/Management/Model/Item.php
@@ -88,7 +88,7 @@ class Item implements ModelInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge([
             'id' => $this->id,

--- a/src/Management/Model/SearchEngine.php
+++ b/src/Management/Model/SearchEngine.php
@@ -204,7 +204,7 @@ class SearchEngine implements ModelInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'language' => $this->language,


### PR DESCRIPTION
Starting with PHP 8, it is required to annotate the return type of `jsonSerialize()` methods for objects that implement `\JsonSerializable`.

Without this, one would run into the following fatal error (for example):

```
PHP Fatal error:  During inheritance of JsonSerializable: Uncaught Exception: Deprecated Functionality: Return type of Doofinder\Management\Model\Item::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/doofinder/doofinder/src/Management/Model/Item.php on line 91
```