### PR TITLE
The code passed to the Exception parent should be an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- The code passed to the Exception parent should be an integer
+  - Exception::__construct(): Argument #2 ($code) must be of type int
+
 ## [7.0.4] - 2023-03-13
 ### Changed
 - Deprecated "site_url" field in Search Engine object

--- a/src/Shared/Exceptions/ApiException.php
+++ b/src/Shared/Exceptions/ApiException.php
@@ -22,7 +22,7 @@ class ApiException extends Exception
      */
     public function __construct($message = "", $code = 0, $exception = null, $responseBody = null)
     {
-        parent::__construct($message, $code, $exception);
+        parent::__construct($message, (int)$code, $exception);
 
         $this->body = $responseBody;
     }


### PR DESCRIPTION
### Fixed
- The code passed to the Exception parent should be an integer
  - Exception::__construct(): Argument #2 ($code) must be of type int